### PR TITLE
Refactor CLI with argparse and add JSONL export

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,17 @@ push the resulting dataset to the [Hugging Face Hub](https://huggingface.co/data
 
 ```bash
 pip install -r requirements.txt
-export HF_TOKEN=your_huggingface_token
-export HF_REPO=yourname/nvd-cve-markdown
-python nvd_to_md.py
+python nvd_to_md.py \
+    --hf-token your_huggingface_token \
+    --repo-id yourname/nvd-cve-markdown
 ```
 
-Optional environment variables:
-- `START_YEAR` – first year to download (default `2002`)
-- `END_YEAR` – last year to download (default current year)
+Optional arguments:
+
+- `--start-year` – first year to download (default `2002`)
+- `--end-year` – last year to download (default current year)
+- `--save-jsonl` – path to write records as JSON Lines before uploading
+- `--no-push` – skip uploading the dataset to the Hugging Face Hub
 
 The dataset uploaded to Hugging Face contains at least two columns:
 - `id` – CVE identifier

--- a/nvd_to_md.py
+++ b/nvd_to_md.py
@@ -1,19 +1,14 @@
 #!/usr/bin/env python3
 """Download NVD CVE records, convert to Markdown and push to Hugging Face datasets.
 
-This script iterates over all yearly NVD CVE JSON feeds, transforms each entry to a
-compact Markdown representation and uploads the result as a dataset to the
-Hugging Face Hub.
-
-Environment variables required:
-    HF_TOKEN  – Hugging Face authentication token
-    HF_REPO   – Dataset repository id, e.g. "username/nvd-cve-markdown"
-Optional variables:
-    START_YEAR – first year to download (default 2002)
-    END_YEAR   – last year to download (default current year)
+This script iterates over yearly NVD CVE JSON feeds, transforms each entry to a
+compact Markdown representation and optionally uploads the result as a dataset
+to the Hugging Face Hub. All configuration is done via command line arguments
+with environment variable fallbacks for convenience.
 """
 from __future__ import annotations
 
+import argparse
 import datetime
 import gzip
 import io
@@ -30,16 +25,51 @@ from tqdm.auto import tqdm
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-HF_TOKEN = os.getenv("HF_TOKEN")
-REPO_ID = os.getenv("HF_REPO")  # e.g. "yourname/nvd-cve-markdown"
-START_YR = int(os.getenv("START_YEAR", "2002"))
-END_YR = int(os.getenv("END_YEAR", str(datetime.datetime.utcnow().year)))
-
-assert HF_TOKEN and REPO_ID, "Set HF_TOKEN and HF_REPO environment variables"
-
 NVD_URL_FMT = (
     "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-{year}.json.gz"
 )
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Download NVD CVE records and create a dataset"
+    )
+    parser.add_argument(
+        "--hf-token",
+        default=os.getenv("HF_TOKEN"),
+        help="Hugging Face authentication token",
+    )
+    parser.add_argument(
+        "--repo-id",
+        default=os.getenv("HF_REPO"),
+        help="Dataset repository id, e.g. 'username/nvd-cve-markdown'",
+    )
+    parser.add_argument(
+        "--start-year",
+        type=int,
+        default=int(os.getenv("START_YEAR", "2002")),
+        help="First year to download (default 2002)",
+    )
+    parser.add_argument(
+        "--end-year",
+        type=int,
+        default=int(os.getenv("END_YEAR", str(datetime.datetime.utcnow().year))),
+        help="Last year to download (default current year)",
+    )
+    parser.add_argument(
+        "--save-jsonl",
+        help="Path to save records as JSON Lines",
+    )
+    parser.add_argument(
+        "--no-push",
+        action="store_true",
+        help="Do not push the dataset to the Hugging Face Hub",
+    )
+    args = parser.parse_args()
+    if not args.no_push and (not args.hf_token or not args.repo_id):
+        parser.error("HF token and repo id are required unless --no-push is set")
+    return args
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -128,21 +158,27 @@ def build_dataset(records: List[Dict]) -> Dataset:
     return dataset
 
 
-def push_dataset(dataset: Dataset) -> None:
-    api = HfApi(token=HF_TOKEN)
+def push_dataset(dataset: Dataset, hf_token: str, repo_id: str) -> None:
+    api = HfApi(token=hf_token)
     try:
-        api.create_repo(repo_id=REPO_ID, repo_type="dataset", exist_ok=True)
+        api.create_repo(repo_id=repo_id, repo_type="dataset", exist_ok=True)
     except Exception as exc:  # pragma: no cover - defensive; hub returns 409
         print("Repo creation skipped / already exists:", exc)
     print("Pushing dataset to Hub… this can take a while.")
-    dataset.push_to_hub(REPO_ID, token=HF_TOKEN, split="train")
-    print(f"✅ Done! View it at https://huggingface.co/datasets/{REPO_ID}")
+    dataset.push_to_hub(repo_id, token=hf_token, split="train")
+    print(f"✅ Done! View it at https://huggingface.co/datasets/{repo_id}")
 
 
 def main() -> None:
-    records = build_records(START_YR, END_YR)
+    args = parse_args()
+    records = build_records(args.start_year, args.end_year)
+    if args.save_jsonl:
+        with open(args.save_jsonl, "w", encoding="utf-8") as fh:
+            for rec in records:
+                fh.write(json.dumps(rec) + "\n")
     dataset = build_dataset(records)
-    push_dataset(dataset)
+    if not args.no_push:
+        push_dataset(dataset, args.hf_token, args.repo_id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace environment variable configuration with an argparse CLI
- allow optionally exporting records to a local JSONL file
- document new CLI usage and options

## Testing
- `python -m py_compile nvd_to_md.py`
- `python nvd_to_md.py --help`
- `python nvd_to_md.py --start-year 2002 --end-year 2002 --no-push --save-jsonl sample.jsonl`

------
https://chatgpt.com/codex/tasks/task_e_6894c162530883288118cb81d588f5ac