### PR TITLE
Include CVSS metrics and CWE mapping in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ Optional arguments:
 The dataset uploaded to Hugging Face contains at least two columns:
 - `id` – CVE identifier
 - `text` – Markdown text with description and references
-
-Additional metadata like publication dates and CVSS metrics are also included.
+Additional metadata like publication dates, CVSS metrics, and mapped CWE
+weaknesses are also included.


### PR DESCRIPTION
## Summary
- collect CVSS metrics and CWE weaknesses when extracting markdown
- add `cvss` and `weaknesses` columns to saved records and dataset
- document additional metadata in README

## Testing
- `python -m py_compile nvd_to_md.py`
- `python nvd_to_md.py --start-year 2002 --end-year 2002 --no-push --save-jsonl /tmp/sample.jsonl`


------
https://chatgpt.com/codex/tasks/task_e_6894d49fa5ec83289bef3e01c23e8469