### PR TITLE
Include CWE names in markdown output

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ The dataset uploaded to Hugging Face contains at least two columns:
 - `id` – CVE identifier
 - `text` – Markdown text with description and references
 Additional metadata like publication dates, CVSS metrics, and mapped CWE
-weaknesses are also included.
+weaknesses with their official names are also included.


### PR DESCRIPTION
## Summary
- lookup CWE titles from OWASP dictionary
- append CWE names after IDs in generated markdown

## Testing
- `python -m py_compile nvd_to_md.py`
- `python - <<'PY'
import gzip, io, json, requests
import nvd_to_md
url = nvd_to_md.NVD_URL_FMT.format(year=2023)
resp = requests.get(url, timeout=120)
with gzip.GzipFile(fileobj=io.BytesIO(resp.content)) as gz:
    feed = json.load(gz)
item = feed['CVE_Items'][0]
md, cvss, weaknesses = nvd_to_md.extract_markdown(item)
print(weaknesses)
print('\n'.join(md.splitlines()[:15]))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6894dccb900483288ca34d40f88675e4