### PR TITLE
Add dataset statistics and README generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ The dataset uploaded to Hugging Face contains at least two columns:
 - `text` – Markdown text with description and references
 Additional metadata like publication dates, CVSS metrics, and mapped CWE
 weaknesses with their official names are also included.
+
+When the dataset is pushed to the Hub the script now also generates a
+README with the current update date and basic statistics such as the total
+number of records and the covered publication range.


### PR DESCRIPTION
## Summary
- compute dataset statistics (record count, date ranges, text length)
- generate and upload dataset README with update date and stats
- note README generation in project docs

## Testing
- `python -m py_compile nvd_to_md.py`
- `python - <<'PY'
from nvd_to_md import build_records, build_dataset, calculate_statistics
recs = build_records(2002, 2002)
print('records', len(recs))
ds = build_dataset(recs)
stats = calculate_statistics(ds)
print(stats)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6894df8594248328a92035f830da759c