### PR TITLE
Reorder CVSS metrics and dedupe CWE list

### DIFF
--- a/nvd_to_md.py
+++ b/nvd_to_md.py
@@ -162,6 +162,9 @@ def extract_markdown(item: Dict) -> tuple[str, List[Dict], List[str]]:
                         val = f"{val}: {name}"
                 weaknesses.append(val)
 
+    # Deduplicate weaknesses while preserving order
+    weaknesses = list(dict.fromkeys(weaknesses))
+
     # ---------- References ----------
     refs = [r["url"] for r in item["cve"]["references"]["reference_data"] if "url" in r]
 
@@ -182,8 +185,8 @@ def extract_markdown(item: Dict) -> tuple[str, List[Dict], List[str]]:
         for metric in cvss:
             md_lines += [
                 f"### Version {metric['version']}",
-                f"*Base Score*: **{metric['score']}** ({metric['severity']})  ",
-                f"*Vector*: `{metric['vector']}`",
+                f"*Vector*: `{metric['vector']}`  ",
+                f"*Base Score*: **{metric['score']}** ({metric['severity']})",
                 "",
             ]
         if md_lines[-1] == "":


### PR DESCRIPTION
## Summary
- Display CVSS vector before base score in generated Markdown
- Remove duplicate CWE entries to keep weaknesses list unique

## Testing
- `python -m py_compile nvd_to_md.py`
- `python - <<'PY'
from nvd_to_md import extract_markdown
mock_item = {
 "cve": {
  "CVE_data_meta": {"ID": "CVE-1234-0001"},
  "description": {"description_data": [{"lang": "en", "value": "Example"}]},
  "problemtype": {"problemtype_data": [
     {"description": [{"lang":"en","value":"CWE-79"}, {"lang":"en","value":"CWE-79"}]}
  ]},
  "references": {"reference_data": []}
 },
 "publishedDate": "2024-01-01",
 "lastModifiedDate": "2024-01-02",
 "impact": {
  "baseMetricV3": {"cvssV3": {"version":"3.1","baseScore":7.5,"baseSeverity":"HIGH","vectorString":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}}
 }
}
md, cvss, weaknesses = extract_markdown(mock_item)
print(md)
print("Weaknesses:", weaknesses)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6894e27704508328a11f8b0ff0b1acf6