### PR TITLE
Deduplicate reference links

### DIFF
--- a/nvd_to_md.py
+++ b/nvd_to_md.py
@@ -166,7 +166,13 @@ def extract_markdown(item: Dict) -> tuple[str, List[Dict], List[str]]:
     weaknesses = list(dict.fromkeys(weaknesses))
 
     # ---------- References ----------
-    refs = [r["url"] for r in item["cve"]["references"]["reference_data"] if "url" in r]
+    refs = [
+        r["url"]
+        for r in item["cve"]["references"]["reference_data"]
+        if "url" in r
+    ]
+    # Deduplicate references while preserving order
+    refs = list(dict.fromkeys(refs))
 
     # ---------- Markdown assembly ----------
     md_lines = [


### PR DESCRIPTION
## Summary
- deduplicate CVE reference URLs so markdown shows unique links only

## Testing
- `python - <<'PY' from nvd_to_md import extract_markdown ... PY`
- `python -m py_compile nvd_to_md.py`

------
https://chatgpt.com/codex/tasks/task_e_6894efa69b988328978aaf83bae2c8d5